### PR TITLE
fix: Update Anthropic model names and add seed parameter to tester

### DIFF
--- a/scripts/proxy_testing/models.json
+++ b/scripts/proxy_testing/models.json
@@ -12,12 +12,17 @@
     "gpt-3.5-turbo-instruct"
   ],
   "anthropic": [
-    "claude-4-opus",
-    "claude-4-sonnet",
+    "claude-opus-4-20250514",
+    "claude-sonnet-4-20250514",
+    "claude-3-7-sonnet-20250219",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-haiku-20241022",
+    "claude-3-5-sonnet-20240620",
     "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
     "claude-3-haiku-20240307",
-    "claude-2.1"
+    "claude-2.1",
+    "claude-2.0"
   ],
   "azure-openai": [
     "gpt-4o",

--- a/scripts/proxy_testing/tester.py
+++ b/scripts/proxy_testing/tester.py
@@ -715,12 +715,18 @@ def main(
     api_key: Optional[str] = typer.Option(None, "-k", "--api-key", help="API key"),
     proxy_url: Optional[str] = typer.Option(None, "-u", "--proxy-url", help="Proxy URL (if not specified, connects directly to provider)"),
     timeout: int = typer.Option(30, "-t", "--timeout", help="Request timeout in seconds"),
-    models_file: str = typer.Option("./models.json", "--models-file", help="Models configuration file")
+    models_file: str = typer.Option("./models.json", "--models-file", help="Models configuration file"),
+    seed: Optional[int] = typer.Option(None, "--seed", help="Random seed for reproducible test runs")
 ):
     """LLM Proxy Load-Test Script
     
     By default, connects directly to provider APIs. 
     Use --proxy-url to test through a proxy server."""
+    
+    # Set random seed if provided for reproducibility
+    if seed is not None:
+        random.seed(seed)
+        console.print(f"[green]Using random seed: {seed}[/green]")
     
     # Determine if we're in interactive mode
     if interactive is None:


### PR DESCRIPTION
## Summary

This PR fixes incorrect Anthropic model names in the proxy testing script and adds a seed parameter for reproducible test runs.

## Changes

### Fixed Anthropic Model Names
- Replaced incorrect `claude-4-opus` and `claude-4-sonnet` with proper model IDs
- Added latest Claude 4 models:
  - `claude-opus-4-20250514` 
  - `claude-sonnet-4-20250514`
- Added Claude 3.7: `claude-3-7-sonnet-20250219`
- Included Claude 3.5 family models
- Kept Claude 3 and Claude 2 models for compatibility

### Added Seed Parameter
- Added `--seed` parameter to `tester.py` for reproducible test runs
- When provided, sets Python random seed for consistent file/sentence selection
- Displays confirmation message showing the seed being used
- Works with both `single-file` and `all-files` selection modes

## Testing

```bash
# Test with new Claude 4 models
python tester.py -p anthropic -m claude-opus-4-20250514 -n 10

# Test reproducible runs with seed
python tester.py -p anthropic -m claude-sonnet-4-20250514 -n 10 --seed 42
# Running again with same seed produces identical random selections
```

## Impact

- Fixes errors when trying to use Claude 4 models through the proxy
- Enables reproducible testing scenarios for debugging
- No breaking changes - all existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)